### PR TITLE
Patch netcat command to make it compatible with CentOS stemcell

### DIFF
--- a/jobs/grafana/templates/bin/grafana-admin-password
+++ b/jobs/grafana/templates/bin/grafana-admin-password
@@ -5,7 +5,7 @@ set -eu
 retries=60
 for ((i=0; i<=retries; i++)); do
   echo "Waiting for grafana to listen on port <%= p('grafana.server.http_port') %> ($i/$retries)"
-  if nc -z 127.0.0.1 <%= p('grafana.server.http_port') %>; then
+  if nc 127.0.0.1 <%= p('grafana.server.http_port') %> < /dev/null; then
     echo "Grafana is ready"
     break
   fi


### PR DESCRIPTION
Grafana admin password shell script uses "nc -z" command to test Grafana TCP port availability (jobs/grafana/templates/bin/grafana-admin-password).

I propose to replace (line 8) :
```shell
if nc -z 127.0.0.1 <%= p('grafana.server.http_port') %>; then
```
by
```shell
if nc 127.0.0.1 <%= p('grafana.server.http_port') %> < /dev/null; then
```
This command works on both Ubuntu and CentOS stemcells.